### PR TITLE
Made patch extraction optional

### DIFF
--- a/KHPCPatchManager.cs
+++ b/KHPCPatchManager.cs
@@ -25,6 +25,95 @@ public class ListBoxItem{
 	}
 }
 
+namespace OpenKh.Egs{
+	public class ZipManager{
+		public static List<ZipFile> ZipFiles {get{return KHPCPatchManager.ZipFiles;}}
+		
+		private static bool ZipDirectoryExists(string dir){
+			return ZipFiles.Find(x => x.SelectEntries(Path.Combine(dir, "*")).Count > 0) != null;
+		}
+		
+		public static bool ZipFileExists(string file){
+			return ZipFiles.Find(x => x.ContainsEntry(file)) != null;
+		}
+		
+		public static bool DirectoryExists(string dir){
+			return ZipDirectoryExists(dir) || Directory.Exists(dir);
+		}
+		
+		public static bool FileExists(string file){
+			return ZipFileExists(file) || File.Exists(file);
+		}
+		
+		public static IEnumerable<string> GetFiles(string folder){
+			if(ZipDirectoryExists(folder)){
+				List<string> foundFiles = new List<string>();
+				ZipFiles.ForEach(x => {
+					ICollection<ZipEntry> entries = x.SelectEntries(Path.Combine(folder, "*"));
+					foreach(var entry in entries){
+						string filename = entry.FileName.Replace(folder.Replace(@"\", "/") + "/", "");
+						if(!entry.IsDirectory && !foundFiles.Contains(filename)){
+							foundFiles.Add(filename);
+						}
+					}
+				});
+				return foundFiles;
+			}else if(Directory.Exists(folder)){
+				return Directory.EnumerateFiles(folder, "*.*", SearchOption.AllDirectories)
+                            .Select(x => x.Replace($"{folder}\\", "")
+                            .Replace(@"\", "/"));
+			}
+			return Enumerable.Empty<string>();
+		}
+		
+		public static byte[] FileReadAllBytes(string file){
+			if(ZipFileExists(file)){
+				ZipEntry entry = null;
+				foreach(var zipFile in ZipFiles){
+					var entries = zipFile.SelectEntries(file).Where(y => !y.IsDirectory);
+					if(entries.FirstOrDefault() != null){
+						entry = entries.FirstOrDefault();
+						
+						using (var stream = entry.OpenReader()){
+							var bytes = new byte[entry.UncompressedSize];
+							stream.Read(bytes, 0, (int)entry.UncompressedSize);
+							return bytes;
+						}
+					}
+				};
+			}else if(File.Exists(file)){
+				return File.ReadAllBytes(file);
+			}
+			return new byte[0];
+		}
+		
+		public static string[] FileReadAllLines(string file){
+			if(ZipFileExists(file)){
+				byte[] bytes = FileReadAllBytes(file);
+				string text = System.Text.Encoding.ASCII.GetString(bytes);
+				return text.Split(
+					new string[] { Environment.NewLine },
+					StringSplitOptions.None
+				);
+			}else if(File.Exists(file)){
+				return File.ReadAllLines(file);
+			}
+			return new string[0];
+		}
+		
+		public static Stream FileReadStream(string file){
+			if(ZipFileExists(file)){
+				byte[] bytes = FileReadAllBytes(file);
+				return new MemoryStream(bytes);
+			}else if(File.Exists(file)){
+				var stream = File.OpenRead(file);
+				return stream;
+			}
+			return new MemoryStream();
+		}
+	}
+}
+
 public class KHPCPatchManager{	
 	static Assembly ExecutingAssembly = Assembly.GetExecutingAssembly();
 	static string[] EmbeddedLibraries = ExecutingAssembly.GetManifestResourceNames().Where(x => x.EndsWith(".dll")).ToArray();
@@ -118,6 +207,8 @@ public class KHPCPatchManager{
 		Console.WriteLine($"KHPCPatchManager {version}");
 		
 		bool extract_raw = false;
+		bool nobackup = false;
+		bool extractPatch = false;
 		string hedFile = null, pkgFile = null, pkgFolder = null;
 		List<string> originFolder = new List<string>();
 		List<string> patchFolders = new List<string>();
@@ -146,6 +237,10 @@ public class KHPCPatchManager{
 				}else if(Path.GetExtension(args[i]) == ".dddpcpatch"){
 					patchType.Add("DDD");
 					originFolder.Add(args[i]);
+				}else if(args[i] == "-extract"){
+					extractPatch = true;
+				}else if(args[i] == "-nobackup"){
+					nobackup = true;
 				}else if(args[i] == "-raw"){
 					extract_raw = true;
 				}else{
@@ -186,7 +281,7 @@ public class KHPCPatchManager{
 				Console.WriteLine("Done!");
 			}else if(originFolder.Count > 0){
 				if(patchType.Distinct().ToList().Count == 1){
-					ApplyPatch(originFolder, patchType[0]);
+					ApplyPatch(originFolder, patchType[0], null, !nobackup, extractPatch);
 				}else{
 					Console.WriteLine(multiplePatchTypesSelected);
 				}
@@ -225,7 +320,8 @@ public class KHPCPatchManager{
 		if(GUI_Displayed) status.Text = "Extracting " + currentExtraction + $": {percent}%";
 	}
 	
-	static void ApplyPatch(List<string> patchFile, string patchType, string epicFolder = null, bool backupPKG = true){
+	public static List<ZipFile> ZipFiles;
+	static void ApplyPatch(List<string> patchFile, string patchType, string epicFolder = null, bool backupPKG = true, bool extractPatch = false){
 		Console.WriteLine("Applying " + patchType + " patch...");
 		if(epicFolder == null){
 			epicFolder = @"C:\Program Files\Epic Games\KH_1.5_2.5\Image\en\";
@@ -241,27 +337,35 @@ public class KHPCPatchManager{
 				epicFolder = Console.ReadLine().Trim('"');
 			}
 		}
-		Console.WriteLine("Extracting patch...");
-		if(GUI_Displayed) status.Text = $"Extracting patch: 0%";
 		string timestamp = DateTime.Now.ToString("dd_MM_yyyy_HH_mm_ss_ms");
-		string tempFolder = patchFile[0] + "_" + timestamp;
+		string tempFolder = "";
+		if(extractPatch){
+			Console.WriteLine("Extracting patch...");
+			if(GUI_Displayed) status.Text = $"Extracting patch: 0%";
+			tempFolder = patchFile[0] + "_" + timestamp;
+			Directory.CreateDirectory(tempFolder);
+		}
 		MyBackgroundWorker backgroundWorker1 = new MyBackgroundWorker();
 		backgroundWorker1.ProgressChanged += (s,e) => {
 			Console.WriteLine((string)e.UserState);
 			if(GUI_Displayed) status.Text = (string)e.UserState;
 		};
 		backgroundWorker1.DoWork += (s,e) => {
-			Directory.CreateDirectory(tempFolder);
 			string epicBackup = Path.Combine(epicFolder, "backup");
 			Directory.CreateDirectory(epicBackup);
 			
+			ZipFiles = new List<ZipFile>();
 			for(int i=0;i<patchFile.Count;i++){
 				using(ZipFile zip = ZipFile.Read(patchFile[i])){
-					totalFiles = zip.Count;
-					filesExtracted = 0;
-					currentExtraction = patchFile[i];
-					zip.ExtractProgress += new EventHandler<ExtractProgressEventArgs>(ExtractionProgress);
-					zip.ExtractAll(tempFolder, ExtractExistingFileAction.OverwriteSilently);
+					if(extractPatch){
+						totalFiles = zip.Count;
+						filesExtracted = 0;
+						currentExtraction = patchFile[i];
+						zip.ExtractProgress += new EventHandler<ExtractProgressEventArgs>(ExtractionProgress);
+						zip.ExtractAll(tempFolder, ExtractExistingFileAction.OverwriteSilently);
+					}else{
+						ZipFiles.Insert(0, zip);
+					}
 				}
 			}		
 			
@@ -275,24 +379,29 @@ public class KHPCPatchManager{
 				string patchFolder = Path.Combine(tempFolder, khFiles[patchType][i]);
 				string epicPkgBackupFile = Path.Combine(epicBackup, khFiles[patchType][i] + (!backupPKG ? "_" + timestamp : "") + ".pkg");
 				string epicHedBackupFile = Path.Combine(epicBackup, khFiles[patchType][i] + (!backupPKG ? "_" + timestamp : "") + ".hed");
-				if(Directory.Exists(patchFolder) && File.Exists(epicFile)){
-					foundFolder = true;
-					if(File.Exists(epicPkgBackupFile)) File.Delete(epicPkgBackupFile);
-					File.Move(epicFile, epicPkgBackupFile);
-					if(File.Exists(epicHedBackupFile)) File.Delete(epicHedBackupFile);
-					File.Move(epicHedFile, epicHedBackupFile);
-					backgroundWorker1.ReportProgress(0, $"Patching {khFiles[patchType][i]}...");
-					backgroundWorker1.PKG = khFiles[patchType][i];
-					OpenKh.Egs.EgsTools.Patch(epicPkgBackupFile, patchFolder, epicFolder, backgroundWorker1);
-					if(!backupPKG){
+
+				try{
+					if(((!extractPatch && OpenKh.Egs.ZipManager.DirectoryExists(khFiles[patchType][i])) || (extractPatch && Directory.Exists(patchFolder))) && File.Exists(epicFile)){
+						foundFolder = true;
 						if(File.Exists(epicPkgBackupFile)) File.Delete(epicPkgBackupFile);
-						File.Move(Path.Combine(epicFolder, khFiles[patchType][i] + "_" + timestamp + ".pkg"), Path.Combine(epicFolder, khFiles[patchType][i] + ".pkg"));
+						File.Move(epicFile, epicPkgBackupFile);
 						if(File.Exists(epicHedBackupFile)) File.Delete(epicHedBackupFile);
-						File.Move(Path.Combine(epicFolder, khFiles[patchType][i] + "_" + timestamp + ".hed"), Path.Combine(epicFolder, khFiles[patchType][i] + ".hed"));
+						File.Move(epicHedFile, epicHedBackupFile);
+						backgroundWorker1.ReportProgress(0, $"Patching {khFiles[patchType][i]}...");
+						backgroundWorker1.PKG = khFiles[patchType][i];
+							OpenKh.Egs.EgsTools.Patch(epicPkgBackupFile, (!extractPatch ? khFiles[patchType][i] : patchFolder), epicFolder, backgroundWorker1);
+						if(!backupPKG){
+							if(File.Exists(epicPkgBackupFile)) File.Delete(epicPkgBackupFile);
+							File.Move(Path.Combine(epicFolder, khFiles[patchType][i] + "_" + timestamp + ".pkg"), Path.Combine(epicFolder, khFiles[patchType][i] + ".pkg"));
+							if(File.Exists(epicHedBackupFile)) File.Delete(epicHedBackupFile);
+							File.Move(Path.Combine(epicFolder, khFiles[patchType][i] + "_" + timestamp + ".hed"), Path.Combine(epicFolder, khFiles[patchType][i] + ".hed"));
+						}
 					}
+				}catch(Exception ex){
+					Console.WriteLine(ex.ToString());
 				}
 			}
-			Directory.Delete(tempFolder, true);
+			if(extractPatch && Directory.Exists(tempFolder)) Directory.Delete(tempFolder, true);
 			if(!foundFolder){
 				string error = "Could not find any folder to patch!\nMake sure you are using the correct path for the \"en\" folder!";
 				Console.WriteLine(error);
@@ -353,6 +462,12 @@ public class KHPCPatchManager{
 		backupOption.Checked = true;
 		backupOption.Click += (s,e) => backupOption.Checked = !backupOption.Checked;
         item.MenuItems.AddRange(new MenuItem[]{backupOption});
+		
+		MenuItem extractOption = new MenuItem();
+		extractOption.Text = "Extract patch before applying";
+		extractOption.Checked = false;
+		extractOption.Click += (s,e) => extractOption.Checked = !extractOption.Checked;
+        item.MenuItems.AddRange(new MenuItem[]{extractOption});
 		
 		item = new MenuItem("?");
         f.Menu.MenuItems.Add(item);
@@ -454,7 +569,8 @@ public class KHPCPatchManager{
 							selPatchButton.Enabled = false;
 							applyPatchButton.Enabled = false;
 							backupOption.Enabled = false;
-							ApplyPatch(patchFiles.ToList(), patchType[0], epicFolder, backupOption.Checked);
+							extractOption.Enabled = false;
+							ApplyPatch(patchFiles.ToList(), patchType[0], epicFolder, backupOption.Checked, extractOption.Checked);
 						}else{
 							MessageBox.Show("Could not find \"\\Image\\en\" in the provided folder!\nPlease try again by selecting the correct folder.");
 						}
@@ -464,7 +580,7 @@ public class KHPCPatchManager{
 				selPatchButton.Enabled = false;
 				applyPatchButton.Enabled = false;
 				backupOption.Enabled = false;
-				ApplyPatch(patchFiles.ToList(), patchType[0], epicFolder, backupOption.Checked);
+				ApplyPatch(patchFiles.ToList(), patchType[0], epicFolder, backupOption.Checked, extractOption.Checked);
 			}
 		};
 		f.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);

--- a/OpenKH/egsTools.cs
+++ b/OpenKH/egsTools.cs
@@ -159,11 +159,11 @@ namespace OpenKh.Egs
             // We only get the original files as for me it doesn't make sense to include
             // new "remastered" asset since it must be linked to an original one
             var patchFiles = new List<string>();
-			if(Directory.Exists(Path.Combine(inputFolder, ORIGINAL_FILES_FOLDER_NAME)))
-				patchFiles.AddRange(Helpers.GetAllFiles(Path.Combine(inputFolder, ORIGINAL_FILES_FOLDER_NAME)).ToList());
+			if(ZipManager.DirectoryExists(Path.Combine(inputFolder, ORIGINAL_FILES_FOLDER_NAME)))
+				patchFiles.AddRange(ZipManager.GetFiles(Path.Combine(inputFolder, ORIGINAL_FILES_FOLDER_NAME)).ToList());
 			
-			if(Directory.Exists(Path.Combine(inputFolder, RAW_FILES_FOLDER_NAME)))
-				patchFiles.AddRange(Helpers.GetAllFiles(Path.Combine(inputFolder, RAW_FILES_FOLDER_NAME)).ToList());
+			if(ZipManager.DirectoryExists(Path.Combine(inputFolder, RAW_FILES_FOLDER_NAME)))
+				patchFiles.AddRange(ZipManager.GetFiles(Path.Combine(inputFolder, RAW_FILES_FOLDER_NAME)).ToList());
 
             var filenames = new List<string>();
 
@@ -200,7 +200,7 @@ namespace OpenKh.Egs
                     {
                     	filename = tempname;
 						Console.WriteLine($"Wait, actually I found it in your patch: {filename}");
-						File.AppendAllText("resources/custom_filenames.txt", filename + "\n");
+						File.AppendAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "resources/custom_filenames.txt"), filename + "\n");
                     }
                     else
                     {
@@ -244,13 +244,13 @@ namespace OpenKh.Egs
 			int actualLength = 0;
 			
             #region Data
-			if(File.Exists(completeFilePath)){
-				using var newFileStream = File.OpenRead(completeFilePath);
+			if(ZipManager.FileExists(completeFilePath)){
+				using var newFileStream = ZipManager.FileReadStream(completeFilePath);
 				actualLength = (int)newFileStream.Length;
 				
 				bool RemasterExist = false;
 				string RemasteredPath = completeFilePath.Replace("\\original\\", "\\remastered\\");
-				if (Directory.Exists(RemasteredPath))
+				if (ZipManager.DirectoryExists(RemasteredPath))
 					RemasterExist = true;
 
 				var header = new EgsHdAsset.Header()
@@ -308,8 +308,8 @@ namespace OpenKh.Egs
 					// Make sure to write the original file after remastered assets headers
 					pkgStream.Write(encryptedData);
 				}
-			}else if(File.Exists(completeRawFilePath)){
-				var newFileStream = File.ReadAllBytes(completeRawFilePath);
+			}else if(ZipManager.FileExists(completeRawFilePath)){
+				var newFileStream = ZipManager.FileReadAllBytes(completeRawFilePath);
 				actualLength = BitConverter.ToInt32(newFileStream, 0);
 				
 				pkgStream.Write(newFileStream);
@@ -327,7 +327,7 @@ namespace OpenKh.Egs
             };
 			
             if (!Names.TryGetValue(Helpers.ToString(hedHeader.MD5), out var existingfilename)){
-				File.AppendAllText("resources/custom_filenames.txt", filename + "\n");
+				File.AppendAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "resources/custom_filenames.txt"), filename + "\n");
             }
 
             BinaryMapping.WriteObject<Hed.Entry>(hedStream, hedHeader);
@@ -368,19 +368,19 @@ namespace OpenKh.Egs
 
 			SDasset sdasset = null;
             // We want to replace the original file
-            if (File.Exists(completeFilePath))
+            if (ZipManager.FileExists(completeFilePath))
             {
 				bool RemasterExist = false;
 				
                 Console.WriteLine($"Replacing original: {filename}!");
 				string RemasteredPath = completeFilePath.Replace("\\original\\","\\remastered\\");
-                if (Directory.Exists(RemasteredPath))
+                if (ZipManager.DirectoryExists(RemasteredPath))
                 {
                     Console.WriteLine($"Remastered Folder Exists! Path: {RemasteredPath}");
                     RemasterExist = true;
                 }
 
-                using var newFileStream = File.OpenRead(completeFilePath);
+                using var newFileStream = ZipManager.FileReadStream(completeFilePath);
                 decompressedData = newFileStream.ReadAllBytes();
 				// Make sure to align asset data on 16 bytes
 				if (decompressedData.Length % 0x10 != 0)
@@ -418,8 +418,8 @@ namespace OpenKh.Egs
                 encryptedData = header.CompressedLength > -2 ? EgsEncryption.Encrypt(compressedData, encryptionSeed) : compressedData;
             }
 			
-			if(File.Exists(completeRawFilePath)){
-				var rawFileStream = File.ReadAllBytes(completeRawFilePath);
+			if(ZipManager.FileExists(completeRawFilePath)){
+				var rawFileStream = ZipManager.FileReadAllBytes(completeRawFilePath);
 				actualLength = BitConverter.ToInt32(rawFileStream, 0);
 				
 				pkgStream.Write(rawFileStream);
@@ -515,13 +515,13 @@ namespace OpenKh.Egs
             if (asset.RemasteredAssetHeaders.Values.Count == 0 || offset != asset.RemasteredAssetHeaders.Values.First().Offset) remasteredNames.Clear();
             //grab list of full file paths from current remasteredAssetsFolder path and add them to a list.
             //we use this list later to correctly add the file names to the PKG.
-            if (Directory.Exists(remasteredAssetsFolder) && Directory.GetFiles(remasteredAssetsFolder, "*", SearchOption.AllDirectories).Length > 0) //only do this if there are actually file in it.
+            if (ZipManager.DirectoryExists(remasteredAssetsFolder) && ZipManager.GetFiles(remasteredAssetsFolder).ToList().Count > 0) //only do this if there are actually file in it.
             {
-                remasteredNames.AddRange(Directory.GetFiles(remasteredAssetsFolder, "*", SearchOption.AllDirectories).ToList());
+                remasteredNames.AddRange(ZipManager.GetFiles(remasteredAssetsFolder).ToList());
 				
                 for (int l = 0; l < remasteredNames.Count; l++) //fix names
                 {
-                    remasteredNames[l] = remasteredNames[l].Replace(remasteredAssetsFolder, "").Replace(@"\", "/");
+                    remasteredNames[l] = remasteredNames[l].Replace(remasteredAssetsFolder + "/", "").Replace(@"\", "/");
                     remasteredNames[l] = Path.ChangeExtension(remasteredNames[l], Path.GetExtension(remasteredNames[l]).ToLower());
                 }
 
@@ -532,7 +532,7 @@ namespace OpenKh.Egs
                     List<string> tempremasteredNames = new List<string>(remasteredNames);
                     for (int i = 0; i < remasteredNames.Count; i++)
                     {
-                        var filename = "/-"  + i.ToString();
+                        var filename = "-"  + i.ToString();
                         //Console.WriteLine("TEST for " + filename + ".dds/.png");
                         if (remasteredNames.Contains(filename + ".dds"))
                         {
@@ -566,7 +566,7 @@ namespace OpenKh.Egs
                 //if those criteria aren't met then do the old method.
                 if (sdasset != null && !sdasset.Invalid && remasteredNames.Count >= oldRemasteredHeaders.Count && remasteredNames.Count > 0)
                 {
-                    filename = remasteredNames[i].Remove(0, 1);
+                    filename = remasteredNames[i];
                 }
 				
                 var assetFilePath = Path.Combine(remasteredAssetsFolder, filename);
@@ -575,11 +575,11 @@ namespace OpenKh.Egs
                 var assetData = asset.RemasteredAssetsDecompressedData.ContainsKey(filename) ? asset.RemasteredAssetsDecompressedData[filename] : new byte[]{};
                 var decompressedLength = remasteredAssetHeader.DecompressedLength;
 				var originalAssetOffset = remasteredAssetHeader.OriginalAssetOffset;
-                if (File.Exists(assetFilePath))
+                if (ZipManager.FileExists(assetFilePath))
                 {
                     Console.WriteLine($"Replacing remastered file: {relativePath}/{filename}");
 
-                    assetData = File.ReadAllBytes(assetFilePath);
+                    assetData = ZipManager.FileReadAllBytes(assetFilePath);
                     decompressedLength = assetData.Length;
                     assetData = remasteredAssetHeader.CompressedLength > -1 ? Helpers.CompressData(assetData) : assetData;
                     assetData = remasteredAssetHeader.CompressedLength > -2 ? EgsEncryption.Encrypt(assetData, seed) : assetData;
@@ -665,8 +665,8 @@ namespace OpenKh.Egs
 		public AssetConfig(string remasteredAssetsFolder){
 			string config = Path.Combine(remasteredAssetsFolder, "assets.config");
 			
-			if(File.Exists(config)){
-				string[] options = File.ReadAllLines(config);
+			if(ZipManager.FileExists(config)){
+				string[] options = ZipManager.FileReadAllLines(config);
 				for(int i=0;i<options.Length;i++){
 					string option = options[i].ToLower().Replace(" ", "");
 					if(option.StartsWith("#")) continue;


### PR DESCRIPTION
Patches can now be read directly without needing to write their files to a temporary folder, which should lengthen the lifespan of SSDs.